### PR TITLE
Feature/add font

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,33 @@
 # Pull Request Templates
 
-Choose a template to get started:
+## Type of change
 
--   [New Feature](?template=.github/PULL_REQUEST_TEMPLATE/feature_request.md)
--   [Bug Fix](?template=.github/PULL_REQUEST_TEMPLATE/bug_fix.md)
+-   [ ] Feature
+-   [ ] Fix
+
+## Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.
+
+-   [ ] Test A
+-   [ ] Test B
+
+**Test Configuration**:
+
+-   Symfony version : >=6.4
+-   PHP version : >=8.3.2
+
+## Checklist:
+
+-   [ ] My code follows the style guidelines of this project
+-   [ ] I have performed a self-review of my own code
+-   [ ] I have commented my code, particularly in hard-to-understand areas
+-   [ ] I have made corresponding changes to the documentation
+-   [ ] My changes generate no new warnings
+-   [ ] I have added tests that prove my feature works
+-   [ ] New and existing unit tests pass locally with my changes
+-   [ ] Any dependent changes have been merged and published in downstream modules

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Smooth Bills is a web application developed in Symfony for managing quotations a
 
 ## Requirements
 
-| Name                                                   | Version |
-| ------------------------------------------------------ | ------- |
-| <a name="requirement_php"></a> [php](#requirement_php) | >=8.3.2 |
+| Name                                                               | Version |
+| ------------------------------------------------------------------ | ------- |
+| <a name="requirement_php"></a> [php](#requirement_php)             | >=8.3.2 |
+| <a name="requirement_symfony"></a> [Symfony](#requirement_symfony) | >=6.4   |
 
 ## Getting Started
 
@@ -33,6 +34,7 @@ For more shortcuts, take a look at the [Makefile](./Makefile).
 ## Documentation
 
 1. [Build options](docs/build.md).
+2. [Symfony Console Command](docs/symfony_command.md)
 
 ## License
 

--- a/docs/symfony_command.md
+++ b/docs/symfony_command.md
@@ -1,0 +1,53 @@
+# Symfony Console Command Documentation
+
+Symfony's Console component allows you to create command-line commands for various tasks such as running cron jobs, importing/exporting data, or interacting with the database.
+
+## Creating a Command
+
+To create a new command :
+
+-   run the following command `php bin/console make:command CommandName`
+-   edit the corresponding class inside at `src/Command/CommandName.php`
+-   add arguments and options to the command by defining them in the `configure()`method
+-   put the command logic inside the `execute()`method
+
+Here's an example of basic command Class :
+
+```php
+namespace App\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(
+    name: 'my-command',
+    description: 'My command description',
+)]
+class MyCommand extends Command
+{
+
+    public function __construct()
+    {
+        parent::__construct();;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('arg1', InputArgument::REQUIRED, 'My command arg1')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $file = $input->getArgument('file');
+
+        // Logic goes here
+    }
+}
+```

--- a/src/Command/AddFontCommand.php
+++ b/src/Command/AddFontCommand.php
@@ -10,20 +10,20 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 use App\Entity\Font;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Service\FontService;
 
 #[AsCommand(
-    name: 'AddFont',
+    name: 'app:AddFont',
     description: 'Adds a font to the font entity',
 )]
 class AddFontCommand extends Command
 {
-    private $entityManager;
+    private $fontService;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(FontService $fontService)
     {
         parent::__construct();
-        $this->entityManager = $entityManager;
+        $this->fontService = $fontService;
     }
 
     protected function configure(): void
@@ -51,36 +51,23 @@ class AddFontCommand extends Command
             return Command::FAILURE;
         }
 
-        $this->insertFont($fonts);
+        foreach ($fonts as $font) {
+            $fontName = $font['name'];
+
+            try {
+                if($this->fontService->addFontIfNotExists($fontName)){
+                    $io->success(sprintf('Font "%s" has been added successfully.', $fontName));
+                }else{
+                    $io->warning(sprintf('Font "%s" already exists.', $fontName));
+                }
+            } catch (\Exception $e) {
+                $io->error(sprintf('An error occured while adding the font "%s".', $fontName));
+                return Command::FAILURE;
+            }
+        }
+
 
         $io->success('Font JSON file processed successfully.');
-
         return Command::SUCCESS;
-    }
-
-    public function insertFont(array $fonts): void
-    {
-        $entityManager = $this->entityManager;
-        $entityManager->beginTransaction();
-        
-        try {
-            foreach($fonts as $font) {
-                $fontName = $font['name'];
-    
-                $existingFont = $entityManager->getRepository(Font::class)->findOneBy(['name' => $fontName]);
-                if(!$existingFont) {
-                    $newFont = new Font();
-                    $newFont->setName($fontName);
-    
-                    $entityManager->persist($newFont);
-                }
-            }
-            
-            $entityManager->flush();
-            $entityManager->commit();
-        } catch (\Exception $e) {
-            $entityManager->rollback();
-            throw $e;
-        }
     }
 }

--- a/src/Command/AddFontCommand.php
+++ b/src/Command/AddFontCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use App\Entity\Font;
+use Doctrine\ORM\EntityManagerInterface;
+
+#[AsCommand(
+    name: 'AddFont',
+    description: 'Adds a font to the font entity',
+)]
+class AddFontCommand extends Command
+{
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+        $this->entityManager = $entityManager;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('file', InputArgument::REQUIRED, 'The JSON file containing fonts.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $file = $input->getArgument('file');
+
+        if (!file_exists($file)) {
+            $io->error(sprintf('The file "%s" does not exist.', $file));
+            return Command::FAILURE;
+        }
+
+        $jsonContent = file_get_contents($file);
+        $fonts = json_decode($jsonContent, true);
+
+        if ($fonts === null) {
+            $io->error('Unable to parse JSON file.');
+            return Command::FAILURE;
+        }
+
+        $this->insertFont($fonts);
+
+        $io->success('Font JSON file procssed successfully.');
+
+        return Command::SUCCESS;
+    }
+
+    public function insertFont(array $fonts): void
+    {
+        $entityManager = $this->entityManager;
+        $entityManager->beginTransaction();
+        
+        try {
+            foreach($fonts as $font) {
+                $fontName = $font['name'];
+    
+                $existingFont = $entityManager->getRepository(Font::class)->findOneBy(['name' => $fontName]);
+                if(!$existingFont) {
+                    $newFont = new Font();
+                    $newFont->setName($fontName);
+    
+                    $entityManager->persist($newFont);
+                }
+            }
+            
+            $entityManager->flush();
+            $entityManager->commit();
+        } catch (\Exception $e) {
+            $entityManager->rollback();
+            throw $e;
+        }
+    }
+}

--- a/src/Command/AddFontCommand.php
+++ b/src/Command/AddFontCommand.php
@@ -53,7 +53,7 @@ class AddFontCommand extends Command
 
         $this->insertFont($fonts);
 
-        $io->success('Font JSON file procssed successfully.');
+        $io->success('Font JSON file processed successfully.');
 
         return Command::SUCCESS;
     }

--- a/src/Repository/FontRepository.php
+++ b/src/Repository/FontRepository.php
@@ -21,6 +21,16 @@ class FontRepository extends ServiceEntityRepository
         parent::__construct($registry, Font::class);
     }
 
+    public function findOneByName($name): ?Font
+    {
+        return $this->createQueryBuilder('f')
+            ->andWhere('f.name = :val')
+            ->setParameter('val', $name)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+
 //    /**
 //     * @return Font[] Returns an array of Font objects
 //     */

--- a/src/Service/FontService.php
+++ b/src/Service/FontService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Font;
+use App\Repository\FontRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PhpParser\Node\Stmt\TryCatch;
+
+class FontService
+{
+    private $fontRepository;
+    private $entityManager;
+
+    public function __construct(FontRepository $fontRepository, EntityManagerInterface $entityManager)
+    {
+        $this->fontRepository = $fontRepository;
+        $this->entityManager = $entityManager;
+    }
+
+    public function addFontIfNotExists(string $font): bool
+    {
+        $existingFont = $this->fontRepository->findOneByName($font);
+
+        if($existingFont){
+            return false;
+        }
+
+        $newfont = new Font();
+        $newfont->setName($font);
+
+        try {
+            $this->entityManager->persist($newfont);
+            $this->entityManager->flush();
+        } catch (\Exception $e) {
+            $this->entityManager->rollback();
+            throw $e;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
# Pull Request Templates

## Type of change

-   [x] Feature
-   [ ] Fix

## Description

This command adds fonts to the font entity in the Symfony application. It reads font information from a JSON file and inserts the fonts into the database. For more information, visit the [documentation](https://symfonygestiondefacture.atlassian.net/wiki/spaces/~5dd268611cf3c20ef5ff1daa/pages/20480321/Command+AddFont).

## How Has This Been Tested?

I have tested this command by running it with various JSON files containing font data to ensure that fonts are correctly added to the database.

-   [X] Test with sample JSON  file containing multiple fonts
-   [X] Test without Json file as argument
-   [ ] Test with a malformed JSON file

**Test Configuration**:

-   Symfony version : 6.4
-   PHP version : >=8.3.2

## Checklist:

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [X] My changes generate no new warnings
-   [ ] I have added tests that prove my feature works
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
