### PR TITLE
Feature/auto invoice reminder

### DIFF
--- a/migrations/Version20240626224737.php
+++ b/migrations/Version20240626224737.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240626224737 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'added due_date column to invoice table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE invoice ADD due_date TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE invoice DROP due_date');
+    }
+}

--- a/src/Command/SendInvoiceReminderCommand.php
+++ b/src/Command/SendInvoiceReminderCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use App\Repository\InvoiceRepository;
+use App\Service\InvoiceService;
+
+
+#[AsCommand(
+    name: 'SendInvoiceReminderCommand',
+    description: 'Send reminders for overdue invoices.',
+)]
+class SendInvoiceReminderCommand extends Command
+{
+    protected static $defaultName = 'app:send-invoice-reminders';
+    private $invoiceRepository;
+    private $invoiceService;
+
+    public function __construct(InvoiceRepository $invoiceRepository, InvoiceService $invoiceService)
+    {
+        parent::__construct();
+        $this->invoiceRepository = $invoiceRepository;
+        $this->invoiceService = $invoiceService;
+    }
+
+    protected function configure()
+    {
+        $this->setDescription('Send reminders for overdue invoices.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $today = new \DateTime();
+        $overdueInvoices = $this->invoiceRepository->findOverdueInvoices($today);
+
+        foreach ($overdueInvoices as $invoice) {
+            $this->invoiceService->sendInvoiceReminder($invoice);
+        }
+
+        $output->writeln('Reminders sent successfully!');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Entity/Invoice.php
+++ b/src/Entity/Invoice.php
@@ -37,6 +37,9 @@ class Invoice
     #[ORM\JoinColumn(nullable: false)]
     private ?Quotation $quotation = null;
 
+    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: false)]
+    private ?\DateTimeInterface $due_date = null;
+
     public function __construct()
     {
         $this->UuidConstruct();
@@ -88,6 +91,17 @@ class Invoice
     public function setQuotation(?Quotation $quotation): static
     {
         $this->quotation = $quotation;
+        return $this;
+    }
+
+    public function getDueDate(): ?\DateTimeInterface
+    {
+        return $this->due_date;
+    }
+
+    public function setDueDate(\DateTimeInterface $due_date): static
+    {
+        $this->due_date = $due_date;
         return $this;
     }
 }

--- a/src/Repository/InvoiceRepository.php
+++ b/src/Repository/InvoiceRepository.php
@@ -88,4 +88,15 @@ class InvoiceRepository extends ServiceEntityRepository
             'client' => $customerName,
         ];
     }
+
+    public function findOverdueInvoices(\DateTime $date): array
+    {
+        return $this->createQueryBuilder('i')
+            ->where('i.due_date < :date')
+            ->andWhere('i.invoiceStatus.name != :paid')
+            ->setParameter('date', $date)
+            ->setParameter('paid', 'paid')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Service/InvoiceService.php
+++ b/src/Service/InvoiceService.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Bridge\Twig\Mime\TemplatedEmail;
 use Symfony\Component\Mime\Address;
 use Twig\Environment;
+use App\Service\PdfGeneratorService;
 
 class InvoiceService
 {
@@ -50,7 +51,7 @@ class InvoiceService
         $this->adminEmail = $adminEmail;
     }
 
-    public function createInvoice(Quotation $quotation): void
+    public function createInvoice(Quotation $quotation): Invoice
     {
         $this->entityManager->beginTransaction();
 
@@ -70,6 +71,7 @@ class InvoiceService
             $this->entityManager->flush();
 
             $this->entityManager->commit();
+            return $invoice;
         } catch (Exception | OptimisticLockException $e) {
             $this->entityManager->rollback();
             throw $e;

--- a/templates/dashboard/invoice/mail/invoice_reminder.html.twig
+++ b/templates/dashboard/invoice/mail/invoice_reminder.html.twig
@@ -1,0 +1,13 @@
+
+<div style="font-family: Arial, sans-serif; color: #333;">
+    <h1 style="font-weight: bold; font-size: 1.25rem; text-align: center; margin-bottom: 20px;">{{ company_name }}</h1>
+    <h2 style="font-weight: 600; color: #666;">Relance de facture impayée</h2>
+    <p>Bonjour {{ customer_name }},</p>
+    <p>
+        Nous vous rappelons que votre facture n°{{ invoice_number }} émise le {{ sending_date }} est toujours impayée.
+    </p>
+    <p>Nous vous remercions de bien vouloir procéder au règlement dans les plus brefs délais.</p>
+
+    <p style="margin-top: 40px;">Merci pour votre confiance !</p>
+    <p>L'équipe {{ company_name }}</p>
+</div>


### PR DESCRIPTION
# Pull Request Template

## Type of change

-   [x] Feature
-   [ ] Fix

## Description

### Summary
This pull request introduces an automated reminder system for overdue invoices. The system includes the following features:
- **Automatic Due Date Assignment**: Each newly created invoice will have a `due_date` set to 30 days after its creation date.
- **Automated Email Reminders**: Once the due date has passed, an email reminder will be sent to the customer for overdue invoices. This email will include a customized message and the overdue invoice attached as a PDF.

### Details
1. **Entity Changes**:
    - Added a `due_date` field to the `Invoice` entity.
    - The `createInvoice` method in the `InvoiceService` has been updated to set the `due_date` and return the created invoice.

2. **Email Reminder Command**:
    - A new console command, `SendInvoiceReminderCommand`, has been created to handle the sending of reminder emails for overdue invoices.
    - This command queries for overdue invoices and sends a templated email to each customer with the overdue invoice attached as a PDF.

3. **PDF Attachment**:
    - Enhanced the `InvoiceService` to generate PDF invoices and attach them to the reminder emails.
    - Used Twig to create a custom email template for the reminder emails.

### Motivation
The new automated reminder system aims to improve the efficiency of the invoicing process by ensuring timely follow-up on overdue invoices, thus potentially improving cash flow and reducing the administrative burden on staff.

### Dependencies
This feature introduces a dependency on the Symfony Mailer component and the `symfony/console` package for the command-line functionality.

## Related Issue
Please include the issue number here, if applicable.

## Checklist

-   [x] I have read the [contribution guidelines](CONTRIBUTING.md).
-   [x] I have performed a self-review of my own code.
-   [x] I have commented my code, particularly in hard-to-understand areas.
-   [x] I have made corresponding changes to the documentation.
-   [x] My changes generate no new warnings.
-   [x] Any dependent changes have been merged and published in downstream modules.

