### PR TITLE
Fix: subscription implementation for design guide

### DIFF
--- a/templates/site/design_guide/index.html.twig
+++ b/templates/site/design_guide/index.html.twig
@@ -212,11 +212,11 @@
     </section>
     <section class="pt-5 pb-10 border-b border-tertiary/10">
             <h2 class="text-subtitle font-subtitle font-semibold mb-5">Plans d'abonnement</h2>
-            <article class="grid grid-cols-1 lg:grid-cols-2 gap-10">
-                <p>
+            <article class="my-2 gap-10">
+                <p class="my-8">
                     Cette section présente les différents plans d'abonnement disponibles pour les utilisateurs.
                 </p>
-                <div class="col-span-2">
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
                    {% set plans = [
                                         {
                                             id: 1,
@@ -251,8 +251,9 @@
                                             isCurrentPlan: false
                                         }
                                     ] %}
-
-                  <twig:Subscription :plans="plans"  />
+                    {% for plan in plans %}
+                     <twig:Subscription plan="{{ plan|raw }}" />  </twig:Subscription>
+                    {% endfor %}
                 </div>
             </article>
     </section>


### PR DESCRIPTION
# Pull Request

## Type of change

- [ ] Feature
- [x] Fix

## Description

This PR includes fixes for displaying the subscription plans in the design guide. The changes involve updating the Twig template to ensure the plans are correctly rendered.

## How Has This Been Tested?

The changes have been tested locally to verify the correct display of the subscription plans.

- [x] Test A: Verified the display of the subscription plans section
- [ ] Test B

**Test Configuration**:

- Symfony version: >=6.4
- PHP version: >=8.3.2

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
